### PR TITLE
Canvis CI

### DIFF
--- a/.github/workflows/softcatala-qt-qlinguist.yml
+++ b/.github/workflows/softcatala-qt-qlinguist.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  descarregar-i-convertir:
+  descarregar-convertir-i-pujar:
     permissions: write-all
     environment: dev
     runs-on: ubuntu-latest
@@ -35,16 +35,24 @@ jobs:
       run: |
         unzip abiword-tm.tmx.zip
 
-    - name: Convertir els fitxers TMX a QPH
+    - name: Convertir el fitxer TMX a QPH (versionat)
       run: |
-        python TMX2QPH.py abiword-tm.tmx --output=abiword.qph
+        python TMX2QPH.py abiword-tm.tmx --output=abiword-$(date +%s).qph
 
-    - name: Publicar els fitxers QPH
+    - name: Publicar els fitxers QPH com a artefactes
       uses: actions/upload-artifact@v3
       with:
         name: qph-files
         path: |
           *.qph
-    - name: version
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-      id: version
+
+    - name: Publicar els fitxers QPH a git
+      env: 
+        CI_COMMIT_MESSAGE: Actualizació automàtica per CI
+        CI_COMMIT_AUTHOR: Github CI
+      run: |
+        git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+        git config --global user.email "eloitor@users.noreply.github.com"
+        git add *.qph
+        git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
+        git push


### PR DESCRIPTION
- Pujar el fitxer QPH automàticament al repositori, perquè sigui fàcil de descarregar
- Versionar el fitxer amb el timestamp d'unix perquè es pugui seguir un versionat quan es creïn paquets per distribucions
- Petits canvis extres

**A tenir en compte**: s'aniran acumulant fitxers perquè el unixts serà diferent. En un futur llunyà podria ser un problema d'espai i que Github se't queixés; en tal cas només caldria borrar-ne d'antics. Si et molesta molt, podem iterar aquest patch per arribar a una solució. Personalment, no ho veig crític. 